### PR TITLE
refactor: migrate InviteDialog raw Supabase call to entities.FamilyInvitation.create

### DIFF
--- a/src/components/family/InviteDialog.tsx
+++ b/src/components/family/InviteDialog.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import { supabase } from '@/lib/supabase';
-import { searchProfileByEmail, addProfileToFamily } from '@/api/entities';
+import { entities, searchProfileByEmail, addProfileToFamily } from '@/api/entities';
 import { useAuth } from '@/lib/AuthContext';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
@@ -101,17 +100,11 @@ export default function InviteDialog({ open, onOpenChange }: Props) {
     setActionPending(true);
     setError('');
     try {
-      const { data: invite, error: inviteErr } = await supabase
-        .from('family_invitations')
-        .insert({
-          family_id: family.id,
-          email: email.trim().toLowerCase(),
-          role,
-        })
-        .select()
-        .single();
-
-      if (inviteErr) throw inviteErr;
+      const invite = await entities.FamilyInvitation.create({
+        family_id: family.id,
+        email: email.trim().toLowerCase(),
+        role,
+      });
 
       const link = `${window.location.origin}/invite?token=${invite.token}`;
       setInviteLink(link);


### PR DESCRIPTION
## Summary

- Replaces `supabase.from('family_invitations').insert(...).select().single()` with `entities.FamilyInvitation.create(...)` in `InviteDialog.tsx`
- Removes the now-unused `supabase` direct import from the component
- Aligns the component with the project's `entities.*` data-access layer convention

## Test plan

- [ ] All 15 unit tests pass (`npm test`)
- [ ] TypeScript compiles cleanly for this file (pre-existing `@sentry/react` type error is unrelated to this change)
- [ ] Lint passes (`npm run lint`)
- [ ] Manual smoke test: open Family page, click Invite, search for an email not in the system, confirm "Send Invite" still creates an invitation and displays the invite link

🤖 Generated with [Claude Code](https://claude.com/claude-code)