### PR TITLE
feat: add loading and error states to Bank page

### DIFF
--- a/src/components/shared/ErrorAlert.tsx
+++ b/src/components/shared/ErrorAlert.tsx
@@ -1,0 +1,11 @@
+// @ts-nocheck
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+
+export function ErrorAlert({ error }: { error: Error | null }) {
+  return (
+    <Alert variant="destructive" className="m-4">
+      <AlertTitle>Something went wrong</AlertTitle>
+      <AlertDescription>{error?.message ?? "An unexpected error occurred."}</AlertDescription>
+    </Alert>
+  );
+}

--- a/src/components/shared/LoadingSpinner.tsx
+++ b/src/components/shared/LoadingSpinner.tsx
@@ -1,0 +1,7 @@
+export function LoadingSpinner() {
+  return (
+    <div className="flex items-center justify-center h-full py-12">
+      <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+    </div>
+  );
+}

--- a/src/pages/Bank.tsx
+++ b/src/pages/Bank.tsx
@@ -13,6 +13,9 @@ import AnimatedNumber from "@/components/shared/AnimatedNumber";
 import { formatDate } from "@/components/shared/weekUtils";
 import { cn } from "@/lib/utils";
 import { soundCashOut, soundPaid } from "@/lib/useSound";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { ErrorAlert } from "@/components/shared/ErrorAlert";
+import { useToast } from "@/components/ui/use-toast";
 
 // ── Currency denomination layout ──────────────────────────────────────────────
 
@@ -592,27 +595,43 @@ function StatsBar({ kids, streakMap, payouts }) {
 
 export default function Bank() {
   const queryClient = useQueryClient();
+  const { toast } = useToast();
   const [cashingOutId, setCashingOutId] = useState(null);
   // burstState: { personId, pieces } | null
   const [burstState, setBurstState] = useState(null);
 
-  const { data: people = [] } = useQuery({ queryKey: ["people"], queryFn: () => entities.Profile.list() });
-  const { data: streaks = [] } = useQuery({ queryKey: ["streaks"], queryFn: () => entities.Streak.list(), refetchInterval: 1000 });
-  const { data: payouts = [] } = useQuery({ queryKey: ["payouts"], queryFn: () => entities.Payout.list(), refetchInterval: 1000 });
+  const peopleQuery = useQuery({ queryKey: ["people"], queryFn: () => entities.Profile.list() });
+  const streaksQuery = useQuery({ queryKey: ["streaks"], queryFn: () => entities.Streak.list(), refetchInterval: 1000 });
+  const payoutsQuery = useQuery({ queryKey: ["payouts"], queryFn: () => entities.Payout.list(), refetchInterval: 1000 });
+
+  const people = peopleQuery.data ?? [];
+  const streaks = streaksQuery.data ?? [];
+  const payouts = payoutsQuery.data ?? [];
+
+  const isLoading = peopleQuery.isLoading || streaksQuery.isLoading || payoutsQuery.isLoading;
+  const isError = peopleQuery.isError || streaksQuery.isError || payoutsQuery.isError;
+  const error = peopleQuery.error ?? streaksQuery.error ?? payoutsQuery.error;
+  const streakMap = useMemo(() => Object.fromEntries(streaks.map(s => [s.profile_id, s])), [streaks]);
+
+  const onMutationError = (err) => toast({ title: "Error", description: err.message, variant: "destructive" });
 
   const createPayoutMutation = useMutation({
     mutationFn: (data) => entities.Payout.create(data),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["payouts"] }),
+    onError: onMutationError,
   });
   const updatePayoutMutation = useMutation({
     mutationFn: ({ id, data }) => entities.Payout.update(id, data),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["payouts"] }),
+    onError: onMutationError,
   });
+
+  if (isLoading) return <LoadingSpinner />;
+  if (isError) return <ErrorAlert error={error} />;
 
   const activePeople = people.filter(p => p.active !== false);
   const kids = activePeople.filter(p => !p.is_parent);
   const parents = activePeople.filter(p => p.is_parent);
-  const streakMap = useMemo(() => Object.fromEntries(streaks.map(s => [s.profile_id, s])), [streaks]);
 
   const getKidFinancials = (person) => {
     const earned = streakMap[person.id]?.total_rewards_earned || 0;


### PR DESCRIPTION
## Summary
- Created `src/components/shared/LoadingSpinner.tsx` and `src/components/shared/ErrorAlert.tsx` as reusable shared components
- Refactored the three `useQuery` calls in `Bank.tsx` to expose `isLoading`/`isError`/`error` with early-return guards
- Moved `useMemo` for `streakMap` before early returns to comply with Rules of Hooks
- Extracted shared `onMutationError` toast handler used by both `createPayoutMutation` and `updatePayoutMutation`

## Test plan
- [ ] Verify loading spinner renders while queries are in-flight
- [ ] Verify error alert renders if any query fails
- [ ] Verify destructive toast appears when a payout mutation fails
- [ ] Confirm all 15 unit tests pass (`npm test`)
- [ ] Confirm lint passes on changed files (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)