### PR TITLE
feat: add dev-only logging to Bank and Notifications pages

### DIFF
--- a/src/pages/Bank.tsx
+++ b/src/pages/Bank.tsx
@@ -602,11 +602,23 @@ export default function Bank() {
 
   const createPayoutMutation = useMutation({
     mutationFn: (data) => entities.Payout.create(data),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["payouts"] }),
+    onSuccess: (result) => {
+      if (import.meta.env.DEV) console.log('[Bank] createPayout succeeded', { payoutId: result?.id, amount: result?.amount });
+      queryClient.invalidateQueries({ queryKey: ["payouts"] });
+    },
+    onError: (error) => {
+      if (import.meta.env.DEV) console.error('[Bank] createPayout failed', { error });
+    },
   });
   const updatePayoutMutation = useMutation({
     mutationFn: ({ id, data }) => entities.Payout.update(id, data),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["payouts"] }),
+    onSuccess: (result) => {
+      if (import.meta.env.DEV) console.log('[Bank] updatePayout succeeded', { payoutId: result?.id, newStatus: result?.status });
+      queryClient.invalidateQueries({ queryKey: ["payouts"] });
+    },
+    onError: (error) => {
+      if (import.meta.env.DEV) console.error('[Bank] updatePayout failed', { error });
+    },
   });
 
   const activePeople = people.filter(p => p.active !== false);
@@ -623,6 +635,8 @@ export default function Bank() {
   };
 
   const handleCashOut = async (person, amount) => {
+    if (import.meta.env.DEV) console.log('[Bank] cash out initiated', { profileId: person.id, amount });
+    if (import.meta.env.DEV) console.log('[Bank] sound triggered', { sound: 'soundCashOut' });
     soundCashOut();
     setCashingOutId(person.id);
     // Capture the pieces to burst BEFORE the payout is created (balance will change)
@@ -640,6 +654,8 @@ export default function Bank() {
   };
 
   const handleMarkPaid = async (payout) => {
+    if (import.meta.env.DEV) console.log('[Bank] mark paid initiated', { payoutId: payout.id, profileId: payout.profile_id });
+    if (import.meta.env.DEV) console.log('[Bank] sound triggered', { sound: 'soundPaid' });
     soundPaid();
     await updatePayoutMutation.mutateAsync({ id: payout.id, data: { status: "paid", paid_date: formatDate(new Date()) } });
   };

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -113,11 +113,23 @@ export default function Notifications() {
 
   const updateMutation = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Partial<Notification> }) => entities.Notification.update(id, data) as Promise<Notification>,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["notifications"] }),
+    onSuccess: (_result, variables) => {
+      if (import.meta.env.DEV) console.log('[Notifications] notification marked read', { notificationId: variables.id });
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    },
+    onError: (error, variables) => {
+      if (import.meta.env.DEV) console.error('[Notifications] mark read failed', { notificationId: variables.id, error });
+    },
   });
   const deleteMutation = useMutation({
     mutationFn: (id: string) => entities.Notification.delete(id) as unknown as Promise<void>,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["notifications"] }),
+    onSuccess: (_result, id) => {
+      if (import.meta.env.DEV) console.log('[Notifications] notification deleted', { notificationId: id });
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    },
+    onError: (error, id) => {
+      if (import.meta.env.DEV) console.error('[Notifications] delete failed', { notificationId: id, error });
+    },
   });
 
   const unreadCount = notifications.filter(n => !n.read).length;
@@ -205,8 +217,14 @@ export default function Notifications() {
                       notif={n}
                       people={people}
                       index={i}
-                      onMarkRead={(n) => updateMutation.mutate({ id: n.id, data: { read: true } })}
-                      onDelete={(n) => deleteMutation.mutate(n.id)}
+                      onMarkRead={(n) => {
+                        if (import.meta.env.DEV) console.log('[Notifications] mark read called', { notificationId: n.id });
+                        updateMutation.mutate({ id: n.id, data: { read: true } });
+                      }}
+                      onDelete={(n) => {
+                        if (import.meta.env.DEV) console.log('[Notifications] delete called', { notificationId: n.id });
+                        deleteMutation.mutate(n.id);
+                      }}
                     />
                   ))}
                 </AnimatePresence>


### PR DESCRIPTION
## Summary
- Adds `if (import.meta.env.DEV)` guarded `console.log` / `console.error` calls to `Bank.tsx` and `Notifications.tsx`
- `[Bank]` prefix covers: cash-out initiated, sound triggered (cashOut/paid), mark-paid initiated, createPayout success/error, updatePayout success/error
- `[Notifications]` prefix covers: mark-read called, delete called, mark-read success/error, delete success/error

## Test plan
- [ ] `npm run lint` passes (no ESLint errors)
- [ ] `npm test` passes (15/15 unit tests green)
- [ ] In dev mode (`npm run dev`), triggering cash-out or mark-paid shows `[Bank]` logs in browser console
- [ ] Triggering notification mark-read or delete shows `[Notifications]` logs
- [ ] Production build (`npm run build`) excludes all logging (Vite dead-code-eliminates `import.meta.env.DEV` branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)