### PR TITLE
feat: add dev-only logging to Chores and People pages

### DIFF
--- a/src/pages/Chores.tsx
+++ b/src/pages/Chores.tsx
@@ -129,17 +129,52 @@ export default function Chores() {
   const { data: people = [] } = useQuery({ queryKey: ["people"], queryFn: () => entities.Profile.list() as unknown as Promise<Profile[]> });
 
   const createMutation = useMutation({
-    mutationFn: (data: Partial<Chore>) => entities.Chore.create(data) as Promise<Chore>,
-    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ["chores"] }); setAddOpen(false); },
+    mutationFn: (data: Partial<Chore>) => {
+      if (import.meta.env.DEV) console.log('[Chores] creating chore', { name: data.title, assignedTo: data.assigned_to });
+      return entities.Chore.create(data) as Promise<Chore>;
+    },
+    onSuccess: () => {
+      if (import.meta.env.DEV) console.log('[Chores] chore created successfully');
+      queryClient.invalidateQueries({ queryKey: ["chores"] });
+      setAddOpen(false);
+    },
+    onError: (error) => {
+      if (import.meta.env.DEV) console.error('[Chores] create chore failed', { error });
+    },
   });
   const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: Partial<Chore> }) => entities.Chore.update(id, data) as Promise<Chore>,
-    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ["chores"] }); setEditChore(null); },
+    mutationFn: ({ id, data }: { id: string; data: Partial<Chore> }) => {
+      if (import.meta.env.DEV) console.log('[Chores] updating chore', { choreId: id, changes: data });
+      return entities.Chore.update(id, data) as Promise<Chore>;
+    },
+    onSuccess: () => {
+      if (import.meta.env.DEV) console.log('[Chores] chore updated successfully');
+      queryClient.invalidateQueries({ queryKey: ["chores"] });
+      setEditChore(null);
+    },
+    onError: (error) => {
+      if (import.meta.env.DEV) console.error('[Chores] update chore failed', { error });
+    },
   });
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => entities.Chore.delete(id) as unknown as Promise<void>,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["chores"] }),
+    mutationFn: (id: string) => {
+      const chore = chores.find((c) => c.id === id);
+      if (import.meta.env.DEV) console.log('[Chores] deleting chore', { choreId: id, choreName: chore?.title });
+      return entities.Chore.delete(id) as unknown as Promise<void>;
+    },
+    onSuccess: () => {
+      if (import.meta.env.DEV) console.log('[Chores] chore deleted successfully');
+      queryClient.invalidateQueries({ queryKey: ["chores"] });
+    },
+    onError: (error) => {
+      if (import.meta.env.DEV) console.error('[Chores] delete chore failed', { error });
+    },
   });
+
+  const handleEditChore = (chore: Chore) => {
+    if (import.meta.env.DEV) console.log('[Chores] edit chore dialog opened', { choreId: chore.id, choreName: chore.title });
+    setEditChore(chore);
+  };
 
   const activePeople = people.filter((p) => p.active !== false);
   const activeChores = chores.filter((c) => c.active !== false);
@@ -181,7 +216,7 @@ export default function Chores() {
               <Button
                 className="gap-2 rounded-xl shadow-lg shadow-primary/20 font-semibold h-10"
                 disabled={activePeople.length === 0}
-                onClick={() => setAddOpen(true)}
+                onClick={() => { if (import.meta.env.DEV) console.log('[Chores] add chore dialog opened'); setAddOpen(true); }}
               >
                 <motion.span animate={addOpen ? { rotate: 45 } : { rotate: 0 }} transition={{ type: "spring", stiffness: 300 }} className="flex">
                   <Plus className="w-4 h-4" />
@@ -272,7 +307,7 @@ export default function Chores() {
                         <motion.div key={chore.id} custom={ci}>
                           <ChoreCard
                             chore={chore}
-                            onEdit={setEditChore}
+                            onEdit={handleEditChore}
                             onDelete={(id) => deleteMutation.mutate(id)}
                             isDeleting={deleteMutation.isPending}
                           />
@@ -294,7 +329,7 @@ export default function Chores() {
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
                   {unassigned.map((chore) => (
-                    <ChoreCard key={chore.id} chore={chore} onEdit={setEditChore} onDelete={(id) => deleteMutation.mutate(id)} />
+                    <ChoreCard key={chore.id} chore={chore} onEdit={handleEditChore} onDelete={(id) => deleteMutation.mutate(id)} />
                   ))}
                 </div>
               </motion.div>

--- a/src/pages/People.tsx
+++ b/src/pages/People.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
 import { useState } from "react";
 import { entities } from "@/api/entities";
 import { type Profile, type Chore, type ChoreLog, type Streak } from "@/types/entities";
@@ -31,17 +31,61 @@ export default function People() {
   const { data: streaks = [] } = useQuery({ queryKey: ["streaks"], queryFn: () => entities.Streak.list() as Promise<Streak[]> });
 
   const createMutation = useMutation({
-    mutationFn: (data: Partial<Profile>) => entities.Profile.create({ ...data, family_id: family?.id }) as unknown as Promise<Profile>,
-    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ["people"] }); setAddOpen(false); },
+    mutationFn: (data: Partial<Profile>) => {
+      if (import.meta.env.DEV) console.log('[People] creating person', { name: data.first_name, role: data.role });
+      return entities.Profile.create({ ...data, family_id: family?.id }) as unknown as Promise<Profile>;
+    },
+    onSuccess: () => {
+      if (import.meta.env.DEV) console.log('[People] person created successfully');
+      queryClient.invalidateQueries({ queryKey: ["people"] });
+      setAddOpen(false);
+    },
+    onError: (error) => {
+      if (import.meta.env.DEV) console.error('[People] create person failed', { error });
+    },
   });
   const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: Partial<Profile> }) => entities.Profile.update(id, data) as unknown as Promise<Profile>,
-    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ["people"] }); setEditProfile(null); },
+    mutationFn: ({ id, data }: { id: string; data: Partial<Profile> }) => {
+      if (import.meta.env.DEV) console.log('[People] updating person', { profileId: id, changes: data });
+      return entities.Profile.update(id, data) as unknown as Promise<Profile>;
+    },
+    onSuccess: () => {
+      if (import.meta.env.DEV) console.log('[People] person updated successfully');
+      queryClient.invalidateQueries({ queryKey: ["people"] });
+      setEditProfile(null);
+    },
+    onError: (error) => {
+      if (import.meta.env.DEV) console.error('[People] update person failed', { error });
+    },
   });
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => entities.Profile.delete(id) as unknown as Promise<void>,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["people"] }),
+    mutationFn: (id: string) => {
+      const person = people.find((p) => p.id === id);
+      if (import.meta.env.DEV) console.log('[People] deleting person', { profileId: id, name: person?.first_name });
+      return entities.Profile.delete(id) as unknown as Promise<void>;
+    },
+    onSuccess: () => {
+      if (import.meta.env.DEV) console.log('[People] person deleted successfully');
+      queryClient.invalidateQueries({ queryKey: ["people"] });
+    },
+    onError: (error) => {
+      if (import.meta.env.DEV) console.error('[People] delete person failed', { error });
+    },
   });
+
+  useEffect(() => {
+    if (import.meta.env.DEV && !isParent) console.log('[People] isParent gate enforced: read-only view for non-parent');
+  }, [isParent]);
+
+  const handleOpenAdd = () => {
+    if (import.meta.env.DEV) console.log('[People] add person dialog opened');
+    setAddOpen(true);
+  };
+
+  const handleEditPerson = (person: Profile) => {
+    if (import.meta.env.DEV) console.log('[People] edit person dialog opened', { profileId: person.id, name: person.name });
+    setEditProfile(person);
+  };
 
   const activePeople = people.filter((p) => p.active !== false);
   const activeChores = chores.filter((c) => c.active !== false);
@@ -95,7 +139,7 @@ export default function People() {
             </div>
             {isParent && (
               <motion.div whileHover={{ scale: 1.04 }} whileTap={{ scale: 0.94 }}>
-                <Button className="gap-2 rounded-xl shadow-lg shadow-primary/20 font-semibold h-10" onClick={() => setAddOpen(true)}>
+                <Button className="gap-2 rounded-xl shadow-lg shadow-primary/20 font-semibold h-10" onClick={handleOpenAdd}>
                   <motion.span animate={addOpen ? { rotate: 45 } : { rotate: 0 }} transition={{ type: "spring", stiffness: 300 }} className="flex">
                     <Plus className="w-4 h-4" />
                   </motion.span>
@@ -125,7 +169,7 @@ export default function People() {
               title="No people yet"
               description="Add people to your group to start assigning chores."
               action={isParent ? (
-                <Button className="gap-2 mt-2" onClick={() => setAddOpen(true)}>
+                <Button className="gap-2 mt-2" onClick={handleOpenAdd}>
                   <UserPlus className="w-4 h-4" /> Add your first person
                 </Button>
               ) : undefined}
@@ -141,7 +185,7 @@ export default function People() {
                   person={person}
                   index={i}
                   chores={activeChores.filter((c) => c.assigned_to === person.id)}
-                  onEdit={isParent ? () => setEditProfile(person) : undefined}
+                  onEdit={isParent ? () => handleEditPerson(person) : undefined}
                   onDelete={isParent ? () => deleteMutation.mutate(person.id) : undefined}
                   weeklyStats={weeklyStatsMap[person.id]}
                   streakData={streakMap[person.id] ?? null}


### PR DESCRIPTION
## Summary
- Adds `console.log`/`warn`/`error` instrumentation to `Chores.tsx` and `People.tsx`, all wrapped in `if (import.meta.env.DEV)` guards (zero production output)
- Logs dialog open events, mutation calls (create/update/delete) with relevant IDs and context, mutation success/error callbacks, and the `isParent` read-only gate in People
- Extracted named handler functions (`handleEditChore`, `handleOpenAdd`, `handleEditPerson`) to eliminate duplicated inline lambdas in JSX

## Test plan
- [ ] `npm run typecheck` passes (no type errors)
- [ ] `npm run lint` passes (no ESLint errors)
- [ ] `npm test` passes (all 15 unit tests green)
- [ ] `npm run build` succeeds (production bundle contains no `console.log` calls from these files)
- [ ] In dev mode, opening add/edit dialogs and triggering mutations surfaces expected `[Chores]` / `[People]` log lines in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)