### PR TITLE
feat: add dev-only logging to Dashboard, Settings, FamilySetup, and entities

### DIFF
--- a/src/api/entities.ts
+++ b/src/api/entities.ts
@@ -5,6 +5,7 @@ type Row = Record<string, unknown>;
 function makeEntity(tableName: string) {
   return {
     async list(sort?: string, limit?: number) {
+      if (import.meta.env.DEV) console.log('[api] list', { table: tableName });
       let query = supabase.from(tableName).select('*');
       if (sort) {
         const desc = sort.startsWith('-');
@@ -19,6 +20,7 @@ function makeEntity(tableName: string) {
     },
 
     async filter(filters: Row) {
+      if (import.meta.env.DEV) console.log('[api] filter', { table: tableName, conditions: filters });
       let query = supabase.from(tableName).select('*');
       for (const [key, value] of Object.entries(filters)) {
         query = query.eq(key, value as string);
@@ -29,6 +31,7 @@ function makeEntity(tableName: string) {
     },
 
     async create(data: Row) {
+      if (import.meta.env.DEV) console.log('[api] create', { table: tableName });
       const { data: result, error } = await supabase
         .from(tableName)
         .insert(data)
@@ -39,6 +42,7 @@ function makeEntity(tableName: string) {
     },
 
     async update(id: string, data: Row) {
+      if (import.meta.env.DEV) console.log('[api] update', { table: tableName, id });
       const { data: result, error } = await supabase
         .from(tableName)
         .update({ ...data, updated_at: new Date().toISOString() })
@@ -50,6 +54,7 @@ function makeEntity(tableName: string) {
     },
 
     async delete(id: string) {
+      if (import.meta.env.DEV) console.log('[api] delete', { table: tableName, id });
       const { error } = await supabase.from(tableName).delete().eq('id', id);
       if (error) throw error;
     },
@@ -102,12 +107,14 @@ export const entities = {
 };
 
 export async function searchProfileByEmail(email: string) {
+  if (import.meta.env.DEV) console.log('[api] rpc searchProfileByEmail', { email });
   const { data, error } = await supabase.rpc('search_profile_by_email', { search_email: email });
   if (error) throw error;
   return (data ?? []).map(addProfileComputedFields);
 }
 
 export async function addProfileToFamily(targetProfileId: string, role: 'parent' | 'child') {
+  if (import.meta.env.DEV) console.log('[api] rpc addProfileToFamily', { targetProfileId, role });
   const { error } = await supabase.rpc('add_profile_to_family', {
     target_profile_id: targetProfileId,
     target_role: role,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -172,6 +172,15 @@ export default function Dashboard() {
     totalRewards,
   });
 
+  useEffect(() => {
+    if (!people.length || !chores.length) return;
+    if (import.meta.env.DEV) console.log('[Dashboard] data loaded', {
+      people: people.length,
+      chores: chores.length,
+      logsThisWeek: logs.length,
+    });
+  }, [people.length, chores.length, logs.length]);
+
   // Send notifications when data loads
   useEffect(() => {
     if (!notifEnabled || !people.length || !streaks.length) return;
@@ -202,9 +211,11 @@ export default function Dashboard() {
   const handleToggleNotifications = async () => {
     if (notifEnabled) {
       setNotifEnabled(false);
+      if (import.meta.env.DEV) console.log('[Dashboard] notifications toggled', { enabled: false });
     } else {
       const perm = await requestPermission();
       if (perm === "granted") setNotifEnabled(true);
+      if (import.meta.env.DEV) console.log('[Dashboard] notifications toggled', { enabled: perm === "granted", permission: perm });
     }
   };
 

--- a/src/pages/FamilySetup.tsx
+++ b/src/pages/FamilySetup.tsx
@@ -112,7 +112,15 @@ export default function FamilySetup() {
   const navigate = useNavigate();
   const [step, setStep] = useState(1);
   const [draft, setDraft] = useState<FamilySetupDraft>(() => {
-    return readFamilySetupDraft() ?? createEmptyFamilySetupDraft({ childCount: 0 });
+    const restored = readFamilySetupDraft();
+    if (restored) {
+      if (import.meta.env.DEV) console.log('[FamilySetup] draft restored from sessionStorage', {
+        familyName: restored.familyName,
+        childCount: restored.children.length,
+        spouseEnabled: restored.spouse.enabled,
+      });
+    }
+    return restored ?? createEmptyFamilySetupDraft({ childCount: 0 });
   });
   const [error, setError] = useState('');
   const [saving, setSaving] = useState(false);
@@ -128,6 +136,11 @@ export default function FamilySetup() {
 
   useEffect(() => {
     writeFamilySetupDraft(draft);
+    if (import.meta.env.DEV) console.log('[FamilySetup] draft saved to sessionStorage', {
+      familyName: draft.familyName,
+      childCount: draft.children.length,
+      spouseEnabled: draft.spouse.enabled,
+    });
   }, [draft]);
 
   useEffect(() => {
@@ -169,18 +182,30 @@ export default function FamilySetup() {
 
   const goNext = () => {
     if (step === 1 && Object.keys(parentErrors).length > 0) {
+      if (import.meta.env.DEV) console.warn('[FamilySetup] step 1 validation failed', { errors: parentErrors });
       setError('Fix the parent details before continuing.');
       return;
     }
 
     if (step === 2 && Object.keys(spouseErrors).length > 0) {
+      if (import.meta.env.DEV) console.warn('[FamilySetup] step 2 validation failed', { errors: spouseErrors });
       setError('Fix the spouse invite details before continuing.');
       return;
     }
 
     if (step === 3 && hasChildErrors) {
+      if (import.meta.env.DEV) console.warn('[FamilySetup] step 3 validation failed', { childErrors });
       setError('Fix the child details before continuing.');
       return;
+    }
+
+    if (import.meta.env.DEV) {
+      const stepData =
+        step === 1 ? { familyName: draft.familyName, parentName: `${draft.parent.firstName} ${draft.parent.lastName}`.trim() } :
+        step === 2 ? { spouseEnabled: draft.spouse.enabled, spouseEmail: draft.spouse.email || undefined } :
+        step === 3 ? { childCount: draft.children.length } :
+        {};
+      console.log('[FamilySetup] step completed', { step, ...stepData });
     }
 
     setError('');
@@ -237,6 +262,11 @@ export default function FamilySetup() {
         navigate('/Daily', { replace: true });
         return;
       }
+
+      if (import.meta.env.DEV) console.log('[FamilySetup] createFamilyFromDraft called', {
+        familyName: draft.familyName,
+        memberCount: 1 + (draft.spouse.enabled ? 1 : 0) + draft.children.length,
+      });
 
       await createFamilyFromDraft({
         authUserId: user.id,
@@ -311,10 +341,13 @@ export default function FamilySetup() {
         },
       });
 
+      if (import.meta.env.DEV) console.log('[FamilySetup] family creation success', { familyName: draft.familyName });
+
       clearFamilySetupDraft();
       await refreshProfile();
       navigate('/Daily', { replace: true });
     } catch (submitError: unknown) {
+      if (import.meta.env.DEV) console.error('[FamilySetup] family creation error', { error: submitError });
       setError(submitError instanceof Error ? submitError.message : 'Failed to create family.');
     } finally {
       setSaving(false);

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -341,6 +341,7 @@ export default function Settings() {
 
   const saveFamilyName = useCallback(async () => {
     if (!family || !familyNameInput.trim()) return;
+    if (import.meta.env.DEV) console.log('[Settings] family name update submitted', { newName: familyNameInput.trim() });
     setSavingFamilyName(true);
     await supabase.from('families').update({ name: familyNameInput.trim() }).eq('id', family.id);
     await Promise.all([
@@ -372,6 +373,7 @@ export default function Settings() {
   const updateVar = (key: string, hexVal: string) => {
     const hsl = hexToHsl(hexVal);
     const next: ThemeVars = { ...current, [key]: hsl };
+    if (import.meta.env.DEV) console.log('[Settings] theme token changed', { token: key, value: hsl });
     setCurrent(next); applyTheme(next); setActiveName("");
   };
 
@@ -466,7 +468,10 @@ export default function Settings() {
               <Button
                 variant="outline"
                 className="w-full gap-2 h-10 rounded-xl text-sm font-semibold"
-                onClick={() => setInviteOpen(true)}
+                onClick={() => {
+                  if (import.meta.env.DEV) console.log('[Settings] invite dialog opened');
+                  setInviteOpen(true);
+                }}
               >
                 <UserPlus className="w-4 h-4" /> Invite Member
               </Button>
@@ -644,7 +649,10 @@ export default function Settings() {
             <Button
               variant="outline"
               className="gap-2 h-11 rounded-xl font-semibold text-destructive border-destructive/30 hover:bg-destructive/10 hover:border-destructive"
-              onClick={signOut}
+              onClick={() => {
+                if (import.meta.env.DEV) console.log('[Settings] sign-out triggered');
+                signOut();
+              }}
             >
               <LogOut className="w-4 h-4" /> Sign out
             </Button>


### PR DESCRIPTION
## Summary

- Adds `if (import.meta.env.DEV)` guarded `console.log` calls throughout four files — zero production output
- **`src/api/entities.ts`**: one log per CRUD method inside `makeEntity` (list/filter/create/update/delete) plus both RPC helpers (`searchProfileByEmail`, `addProfileToFamily`)
- **`src/pages/Dashboard.tsx`**: logs data-loaded summary stats (people/chores/logs counts) and notification toggle state
- **`src/pages/Settings.tsx`**: logs theme token changes, family name submission, invite dialog open, and sign-out
- **`src/pages/FamilySetup.tsx`**: logs draft restored/saved to sessionStorage, each wizard step completion with key data, `createFamilyFromDraft` call, success, and errors

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes (no errors)
- [x] `npm test` — 15/15 unit tests pass
- [x] `npm run build` — production build succeeds with exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)