### PR TITLE
feat: add loading and error states to Daily page

### DIFF
--- a/src/components/shared/ErrorAlert.tsx
+++ b/src/components/shared/ErrorAlert.tsx
@@ -1,0 +1,8 @@
+export function ErrorAlert({ error }: { error: Error | null }) {
+  return (
+    <div role="alert" className="m-4 rounded-lg border border-destructive/50 px-4 py-3 text-sm text-destructive">
+      <p className="mb-1 font-medium leading-none tracking-tight">Something went wrong</p>
+      <p className="text-sm">{error?.message ?? "An unexpected error occurred."}</p>
+    </div>
+  );
+}

--- a/src/components/shared/LoadingSpinner.tsx
+++ b/src/components/shared/LoadingSpinner.tsx
@@ -1,0 +1,13 @@
+import { motion } from "framer-motion";
+
+export function LoadingSpinner() {
+  return (
+    <div className="flex items-center justify-center py-24">
+      <motion.div
+        animate={{ rotate: 360 }}
+        transition={{ repeat: Infinity, duration: 0.75, ease: "linear" }}
+        className="w-7 h-7 border-[3px] border-primary border-t-transparent rounded-full"
+      />
+    </div>
+  );
+}

--- a/src/pages/Daily.tsx
+++ b/src/pages/Daily.tsx
@@ -13,6 +13,9 @@ import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { soundComplete, soundUncomplete } from "@/lib/useSound";
 import StampAnimation from "@/components/chores/StampAnimation";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { ErrorAlert } from "@/components/shared/ErrorAlert";
+import { useToast } from "@/components/ui/use-toast";
 
 const DAY_KEY_MAP = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
 
@@ -387,36 +390,48 @@ function PersonSection({ person, personIndex, chores, logMap, onToggle, todayStr
 
 export default function Daily() {
   const queryClient = useQueryClient();
+  const { toast } = useToast();
   const today = new Date();
   const weekStart = getWeekStart(today);
   const weekStartStr = formatDate(weekStart);
   const todayStr = formatDate(today);
 
-  const { data: people = [] } = useQuery({ queryKey: ["people"], queryFn: () => entities.Profile.list() as unknown as Promise<Profile[]> });
-  const { data: chores = [] } = useQuery({ queryKey: ["chores"], queryFn: () => entities.Chore.list() as Promise<Chore[]> });
-  const { data: logs = [] } = useQuery({
+  const { data: people = [], isLoading: isLoadingPeople, isError: isPeopleError, error: peopleError } = useQuery({ queryKey: ["people"], queryFn: () => entities.Profile.list() as unknown as Promise<Profile[]> });
+  const { data: chores = [], isLoading: isLoadingChores, isError: isChoresError, error: choresError } = useQuery({ queryKey: ["chores"], queryFn: () => entities.Chore.list() as Promise<Chore[]> });
+  const { data: logs = [], isLoading: isLoadingLogs, isError: isLogsError, error: logsError } = useQuery({
     queryKey: ["choreLogs", weekStartStr],
     queryFn: () => entities.ChoreLog.filter({ week_start: weekStartStr }) as Promise<ChoreLog[]>,
   });
   const { data: streaks = [] } = useQuery({ queryKey: ["streaks"], queryFn: () => entities.Streak.list() as Promise<Streak[]> });
 
+  const isLoading = isLoadingPeople || isLoadingChores || isLoadingLogs;
+  const isError = isPeopleError || isChoresError || isLogsError;
+  const error = (peopleError || choresError || logsError) as Error | null;
+
   const streakMap = useMemo(() => Object.fromEntries(streaks.map((s: Streak) => [s.profile_id, s])), [streaks]);
+
+  const onMutationError = (err: Error) =>
+    toast({ title: "Error", description: err.message, variant: "destructive" });
 
   const createLogMutation = useMutation({
     mutationFn: (data: Partial<ChoreLog>) => entities.ChoreLog.create(data) as Promise<ChoreLog>,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["choreLogs"] }),
+    onError: onMutationError,
   });
   const deleteLogMutation = useMutation({
     mutationFn: (id: string) => entities.ChoreLog.delete(id) as unknown as Promise<void>,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["choreLogs"] }),
+    onError: onMutationError,
   });
   const updateStreakMutation = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Partial<Streak> }) => entities.Streak.update(id, data) as Promise<Streak>,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["streaks"] }),
+    onError: onMutationError,
   });
   const createStreakMutation = useMutation({
     mutationFn: (data: Partial<Streak>) => entities.Streak.create(data) as Promise<Streak>,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["streaks"] }),
+    onError: onMutationError,
   });
 
   const activePeople = people.filter((p: Profile) => p.active !== false && !p.is_parent);
@@ -480,6 +495,9 @@ export default function Daily() {
     });
     return { total, done, progress: total > 0 ? Math.round((done / total) * 100) : 0 };
   }, [activePeople, activeChores, logMap, todayStr]);
+
+  if (isLoading) return <LoadingSpinner />;
+  if (isError) return <ErrorAlert error={error} />;
 
   const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
   const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];


### PR DESCRIPTION
## Summary

- Created `src/components/shared/LoadingSpinner.tsx` using Framer Motion rotation animation to match existing page-level spinner pattern in `Chores.tsx` and `People.tsx`
- Created `src/components/shared/ErrorAlert.tsx` with a destructive-styled alert using plain HTML (avoids TypeScript issues with the `// @ts-nocheck` Alert component)
- Updated `Daily.tsx` to destructure `isLoading`/`isError`/`error` from the three primary queries (people, chores, logs) and add early-return guards after all hooks
- Added shared `onMutationError` handler wired to all four mutations via `useToast` to show destructive toast notifications on failure

## Test plan

- [ ] Verify spinner displays while queries are loading
- [ ] Verify error alert displays when a query fails
- [ ] Verify toast appears when a chore log mutation fails
- [ ] Run `npm run lint && npm test && npm run build` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)