### PR TITLE
feat: add dev-only logging to auth layer

### DIFF
--- a/src/lib/AuthContext.tsx
+++ b/src/lib/AuthContext.tsx
@@ -33,6 +33,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [authError, setAuthError] = useState<AuthError | null>(null);
 
   const loadProfile = useCallback(async (authUser: User) => {
+    if (import.meta.env.DEV) console.log('[auth] profile load start', { userId: authUser.id, email: authUser.email });
     setIsLoadingProfile(true);
     try {
       // Fetch profile + family in a single query via JOIN
@@ -46,12 +47,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const { families: familyData, ...profileData } = data;
         setProfile(profileData as Profile);
         setFamily((familyData as Family) || null);
+        if (import.meta.env.DEV) console.log('[auth] profile load success', { userId: authUser.id, profileId: profileData.id, familyId: (familyData as Family | null)?.id });
         return;
       }
 
       // No profile — check for a pending invite token saved before OAuth redirect
       const pending = inviteStorage.get();
       if (pending) {
+        if (import.meta.env.DEV) console.log('[auth] pending invite token detected', { token: pending.token });
         const { data: invite } = await supabase
           .from('family_invitations')
           .select('*')
@@ -60,6 +63,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           .maybeSingle();
 
         if (invite) {
+          if (import.meta.env.DEV) console.log('[auth] invite acceptance flow start', { inviteId: invite.id, role: invite.role, familyId: invite.family_id });
           // INSERT profile, UPDATE invitation, and fetch family all in parallel
           const [insertResult, , familyResult] = await Promise.all([
             supabase
@@ -90,13 +94,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           if (insertResult.data) {
             setProfile(insertResult.data as Profile);
             setFamily((familyResult.data as Family) || null);
+            if (import.meta.env.DEV) console.log('[auth] invite acceptance flow end — profile created', { profileId: insertResult.data.id });
           }
         } else {
           // Token invalid or expired
+          if (import.meta.env.DEV) console.warn('[auth] pending invite token invalid or expired', { token: pending.token });
           inviteStorage.clear();
         }
       }
       // If still no profile, App.tsx redirects to /family/setup
+    } catch (error) {
+      if (import.meta.env.DEV) console.error('[auth] profile load failed', { error });
+      throw error;
     } finally {
       setIsLoadingProfile(false);
     }
@@ -119,10 +128,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // so getSession() is not needed and would cause a redundant loadProfile call.
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
       if (session?.user) {
+        if (import.meta.env.DEV) console.log('[auth] user signed in', { event: _event, userId: session.user.id, email: session.user.email });
         setUser(session.user);
         setAuthError(null);
         loadProfile(session.user);
       } else {
+        if (import.meta.env.DEV) console.log('[auth] user signed out', { event: _event });
         setUser(null);
         setProfile(null);
         setFamily(null);
@@ -134,6 +145,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [loadProfile]);
 
   const signOut = async () => {
+    if (import.meta.env.DEV) console.log('[auth] signOut() called');
     if (isE2EMockAuthEnabled()) {
       clearE2EAuthState();
       setUser(null);
@@ -147,6 +159,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const refreshProfile = useCallback(async () => {
+    if (import.meta.env.DEV) console.log('[auth] refreshProfile() called', { userId: user?.id });
     if (isE2EMockAuthEnabled()) {
       const state = readE2EAuthState();
       setUser(state?.user ? (state.user as User) : null);

--- a/src/pages/Invite.tsx
+++ b/src/pages/Invite.tsx
@@ -25,7 +25,13 @@ export default function Invite() {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    if (!token) { setStep('invalid'); return; }
+    if (!token) {
+      if (import.meta.env.DEV) console.warn('[Invite] no invite token found in URL params');
+      setStep('invalid');
+      return;
+    }
+
+    if (import.meta.env.DEV) console.log('[Invite] invite token found — starting invitation lookup', { token });
 
     supabase
       .from('family_invitations')
@@ -34,8 +40,13 @@ export default function Invite() {
       .eq('status', 'pending')
       .maybeSingle()
       .then(({ data }) => {
-        if (!data) { setStep('invalid'); return; }
+        if (!data) {
+          if (import.meta.env.DEV) console.warn('[Invite] invitation lookup failed — token invalid or expired', { token });
+          setStep('invalid');
+          return;
+        }
         const { families: fam, ...invite } = data;
+        if (import.meta.env.DEV) console.log('[Invite] invitation lookup success', { inviteId: invite.id, role: invite.role, familyId: (fam as Family | null)?.id });
         setInvitation(invite as FamilyInvitation);
         setFamily(fam as Family);
         setStep('form');
@@ -56,29 +67,36 @@ export default function Invite() {
   const handleEmailJoin = async () => {
     if (!validateForm()) return;
     if (!password || password.length < 6) {
+      if (import.meta.env.DEV) console.warn('[Invite] form validation failed — password too short');
       setError('Password must be at least 6 characters.');
       return;
     }
+    if (import.meta.env.DEV) console.log('[Invite] auth method chosen: email/password', { email: invitation?.email });
     setError('');
     setLoading(true);
     inviteStorage.save(token, { firstName: firstName.trim(), lastName: lastName.trim() });
+    if (import.meta.env.DEV) console.log('[Invite] profile creation on invite acceptance — signing up with email', { email: invitation?.email });
     const { error: err } = await supabase.auth.signUp({
       email: invitation!.email,
       password,
     });
     if (err) {
+      if (import.meta.env.DEV) console.error('[Invite] email sign-up failed', { error: err });
       inviteStorage.clear();
       setError(err.message);
       setLoading(false);
       return;
     }
+    if (import.meta.env.DEV) console.log('[Invite] email sign-up success — awaiting profile creation via AuthContext');
     setStep('done');
   };
 
   const handleGoogleJoin = () => {
     if (!validateForm()) return;
+    if (import.meta.env.DEV) console.log('[Invite] auth method chosen: Google OAuth', { email: invitation?.email });
     setError('');
     inviteStorage.save(token, { firstName: firstName.trim(), lastName: lastName.trim() });
+    if (import.meta.env.DEV) console.log('[Invite] profile creation on invite acceptance — redirecting to Google OAuth');
     supabase.auth.signInWithOAuth({
       provider: 'google',
       options: { redirectTo: window.location.origin },

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -39,6 +39,7 @@ export default function Login() {
   };
 
   const handleGoogleSignIn = () => {
+    if (import.meta.env.DEV) console.log('[Login] Google OAuth sign-in button clicked');
     seedDraft('google');
 
     if (isE2EMockAuthEnabled()) {
@@ -64,15 +65,18 @@ export default function Login() {
     setError('');
 
     if (!username.trim()) {
+      if (import.meta.env.DEV) console.warn('[Login] form validation failed — username is empty');
       setError('Enter a username.');
       return;
     }
 
     if (password.length < 6) {
+      if (import.meta.env.DEV) console.warn('[Login] form validation failed — password too short');
       setError('Password must be at least 6 characters.');
       return;
     }
 
+    if (import.meta.env.DEV) console.log('[Login] username/password form submitted', { mode, username: username.trim() });
     setLoading(true);
     seedDraft('username');
 
@@ -111,7 +115,10 @@ export default function Login() {
           throw authError;
         }
       }
+
+      if (import.meta.env.DEV) console.log('[Login] auth success — navigating away', { mode });
     } catch (submitError: unknown) {
+      if (import.meta.env.DEV) console.error('[Login] auth error', { error: submitError, mode });
       setError(submitError instanceof Error ? submitError.message : 'Something went wrong.');
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary

- Instruments `AuthContext.tsx` with `[auth]`-prefixed logs at all lifecycle boundaries: sign-in/out events (with `_event` and user context), profile load start/success/error, pending invite token detection, and invite acceptance flow start/end
- Instruments `Login.tsx` with `[Login]`-prefixed logs: Google OAuth click, username/password form submission (mode + username), validation failures, auth success, and caught errors
- Instruments `Invite.tsx` with `[Invite]`-prefixed logs: token found/missing, invitation lookup start/success/failure, auth method chosen (email vs Google), profile creation steps, and sign-up errors
- All logs are wrapped in `if (import.meta.env.DEV)` — zero production output
- Uses `console.log` for normal events, `console.warn` for validation failures, `console.error` for caught errors
- Added `throw error` after the new catch block in `loadProfile` to preserve original error propagation behaviour

## Test plan

- [x] `npm run lint` passes (no ESLint errors)
- [x] `npm test` passes (15/15 unit tests)
- [x] `npm run build` failure is pre-existing (`@sentry/react` missing package, confirmed present on baseline before these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)