### PR TITLE
refactor: migrate FamilySetup raw Supabase inserts to entities helpers

### DIFF
--- a/src/lib/__tests__/familySetupSave.test.ts
+++ b/src/lib/__tests__/familySetupSave.test.ts
@@ -5,8 +5,7 @@ describe('familySetupSave', () => {
   it('creates unassigned chores for email children and assigned chores for username children', async () => {
     const db = {
       createFamily: vi.fn().mockResolvedValue({ id: 'family-1' }),
-      createParentProfile: vi.fn().mockResolvedValue({ id: 'parent-1' }),
-      createChildProfile: vi.fn().mockResolvedValue({ id: 'child-1' }),
+      createProfile: vi.fn().mockResolvedValue({ id: 'child-1' }),
       createInvitation: vi.fn().mockResolvedValue({ id: 'invite-1' }),
       createChore: vi.fn().mockResolvedValue({ id: 'chore-1' }),
     };
@@ -56,7 +55,7 @@ describe('familySetupSave', () => {
       2,
       expect.objectContaining({ title: 'Wash dishes', assigned_to: null }),
     );
-    expect(db.createChildProfile).toHaveBeenCalledWith(
+    expect(db.createProfile).toHaveBeenCalledWith(
       expect.objectContaining({
         birthdate: '2016-01-01',
       }),

--- a/src/lib/familySetupSave.ts
+++ b/src/lib/familySetupSave.ts
@@ -2,8 +2,7 @@ import type { FamilySetupDraft } from './familySetupTypes';
 
 interface FamilySetupDb {
   createFamily: (input: { name: string; created_by: string }) => Promise<{ id: string }>;
-  createParentProfile: (input: Record<string, unknown>) => Promise<{ id: string }>;
-  createChildProfile: (input: Record<string, unknown>) => Promise<{ id: string }>;
+  createProfile: (input: Record<string, unknown>) => Promise<{ id: string }>;
   createInvitation: (input: Record<string, unknown>) => Promise<{ id: string }>;
   createChore: (input: Record<string, unknown>) => Promise<{ id: string }>;
 }
@@ -26,7 +25,7 @@ export async function createFamilyFromDraft({
     created_by: authUserId,
   });
 
-  await db.createParentProfile({
+  await db.createProfile({
     auth_user_id: authUserId,
     first_name: draft.parent.firstName,
     last_name: draft.parent.lastName,
@@ -46,7 +45,7 @@ export async function createFamilyFromDraft({
 
   for (const child of draft.children) {
     if (child.accountMode === 'username') {
-      const profile = await db.createChildProfile({
+      const profile = await db.createProfile({
         first_name: child.firstName,
         last_name: child.lastName,
         email: child.username.trim(),

--- a/src/pages/FamilySetup.tsx
+++ b/src/pages/FamilySetup.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useAuth } from '@/lib/AuthContext';
 import { isE2EMockAuthEnabled, readE2EAuthState, writeE2EAuthState } from '@/lib/e2eAuth';
-import { supabase } from '@/lib/supabase';
+import { entities } from '@/api/entities';
 import { suggestStarterPassword } from '@/lib/familySetupAuth';
 import {
   clearFamilySetupDraft,
@@ -244,69 +244,20 @@ export default function FamilySetup() {
         draft,
         db: {
           async createFamily(input) {
-            const { data, error: queryError } = await supabase
-              .from('families')
-              .insert(input)
-              .select()
-              .single();
-
-            if (queryError || !data) {
-              throw queryError ?? new Error('Failed to create family.');
-            }
-
-            return { id: data.id as string };
+            const row = await entities.Family.create(input);
+            return { id: row.id as string };
           },
-          async createParentProfile(input) {
-            const { data, error: queryError } = await supabase
-              .from('profiles')
-              .insert(input)
-              .select()
-              .single();
-
-            if (queryError || !data) {
-              throw queryError ?? new Error('Failed to create parent profile.');
-            }
-
-            return { id: data.id as string };
-          },
-          async createChildProfile(input) {
-            const { data, error: queryError } = await supabase
-              .from('profiles')
-              .insert(input)
-              .select()
-              .single();
-
-            if (queryError || !data) {
-              throw queryError ?? new Error('Failed to create child profile.');
-            }
-
-            return { id: data.id as string };
+          async createProfile(input) {
+            const row = await entities.Profile.create(input);
+            return { id: row.id as string };
           },
           async createInvitation(input) {
-            const { data, error: queryError } = await supabase
-              .from('family_invitations')
-              .insert(input)
-              .select()
-              .single();
-
-            if (queryError || !data) {
-              throw queryError ?? new Error('Failed to create invitation.');
-            }
-
-            return { id: data.id as string };
+            const row = await entities.FamilyInvitation.create(input);
+            return { id: row.id as string };
           },
           async createChore(input) {
-            const { data, error: queryError } = await supabase
-              .from('chore')
-              .insert(input)
-              .select()
-              .single();
-
-            if (queryError || !data) {
-              throw queryError ?? new Error('Failed to create chore.');
-            }
-
-            return { id: data.id as string };
+            const row = await entities.Chore.create(input);
+            return { id: row.id as string };
           },
         },
       });


### PR DESCRIPTION
## Summary
- Replaces 5 raw `supabase.from().insert()` calls in `createFamilyFromDraft` with `entities.Family/Profile/FamilyInvitation/Chore.create()`
- Collapses duplicate `createParentProfile`/`createChildProfile` interface methods into a single `createProfile` method (found by simplify review)
- Updates test file accordingly

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)